### PR TITLE
Added -fconcepts switch which is needed in recent GCC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 # ... and that concepts are included in C++1z.
 # TODO: What happens when there are different versions of concepts?
-set(CMAKE_REQUIRED_FLAGS -std=c++1z)
+set(CMAKE_REQUIRED_FLAGS -fconcepts)
 check_cxx_concepts(CXX_COMPILER_HAS_CONCEPTS)
 if(NOT CXX_COMPILER_HAS_CONCEPTS)
   message(FATAL_ERROR "${PROJECT_NAME} requires a C++ compiler that supports concepts.")

--- a/origin.graph/CMakeLists.txt
+++ b/origin.graph/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(origin-graph STATIC
   adjacency_list.cpp
   adjacency_vector.cpp)
 
-target_compile_options(origin-graph PUBLIC -std=c++1z)
+target_compile_options(origin-graph PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-graph
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-graph PUBLIC origin-core origin-range)

--- a/origin.math/CMakeLists.txt
+++ b/origin.math/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(origin-math STATIC
   numeric.cpp
   stats.cpp)
 
-target_compile_options(origin-math PUBLIC -std=c++1z)
+target_compile_options(origin-math PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-math
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 

--- a/origin/algorithm/CMakeLists.txt
+++ b/origin/algorithm/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(origin-algorithm STATIC
   quantifier.cpp
   uninitialized.cpp)
 
-target_compile_options(origin-algorithm PUBLIC -std=c++1z)
+target_compile_options(origin-algorithm PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-algorithm
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-algorithm

--- a/origin/core/CMakeLists.txt
+++ b/origin/core/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(origin-core STATIC
   finally.cpp
   type.cpp)
 
-target_compile_options(origin-core PUBLIC -std=c++1z)
+target_compile_options(origin-core PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-core
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 

--- a/origin/data/CMakeLists.txt
+++ b/origin/data/CMakeLists.txt
@@ -17,7 +17,7 @@ add_compiler_export_flags()
 add_library(origin-data STATIC
   vector.cpp)
 
-target_compile_options(origin-data PUBLIC -std=c++1z)
+target_compile_options(origin-data PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-data
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-data

--- a/origin/iterator/CMakeLists.txt
+++ b/origin/iterator/CMakeLists.txt
@@ -16,7 +16,7 @@ add_compiler_export_flags()
 add_library(origin-iterator STATIC
   core.cpp)
 
-target_compile_options(origin-iterator PUBLIC -std=c++1z)
+target_compile_options(origin-iterator PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-iterator
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-iterator PUBLIC origin-core)

--- a/origin/memory/CMakeLists.txt
+++ b/origin/memory/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(origin-memory STATIC
   memory.cpp
   allocator.cpp)
 
-target_compile_options(origin-memory PUBLIC -std=c++1z)
+target_compile_options(origin-memory PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-memory
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-memory PUBLIC origin-core)

--- a/origin/numeric/CMakeLists.txt
+++ b/origin/numeric/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(origin-numeric STATIC
   numeric.cpp
   algebra.cpp)
 
-target_compile_options(origin-numeric PUBLIC -std=c++1z)
+target_compile_options(origin-numeric PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-numeric
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-numeric PUBLIC origin-core)

--- a/origin/range/CMakeLists.txt
+++ b/origin/range/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(origin-range STATIC
   core.cpp
   range.cpp)
 
-target_compile_options(origin-range PUBLIC -std=c++1z)
+target_compile_options(origin-range PUBLIC -std=c++1z -fconcepts)
 target_include_directories(origin-range
   PUBLIC "$<BUILD_INTERFACE:${Origin_SOURCE_DIR};${Origin_BINARY_DIR}>")
 target_link_libraries(origin-range PUBLIC origin-iterator)


### PR DESCRIPTION
It seem the "-fconcepts" flag is required in recent versions of GCC. I've tested the attached changes with (GCC) 7.0.0 20161127; as well as the stock GCC 6.2 included with Ubuntu 16.10.